### PR TITLE
Allow the Google Analytics tracking code to be supplied by other middleware

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,7 @@ Unomena
 
 * Euan Jonker
 
+Appazur.com
+-----------
+
+* Trevor Cox

--- a/google_analytics/templatetags/google_analytics_tags.py
+++ b/google_analytics/templatetags/google_analytics_tags.py
@@ -21,16 +21,20 @@ class GoogleAnalyticsNode(template.Node):
         self.debug = debug
 
     def render(self, context):
-        # Trivial case
-        try:
-            assert settings.GOOGLE_ANALYTICS['google_analytics_id']
-        except:
-            return ''
-
         # attempt get the request from the context
         request = context.get('request', None)
         if request is None:
             raise RuntimeError("Request context required")
+
+        try:
+            if 'request_key' in settings.GOOGLE_ANALYTICS:
+                account = getattr(request, settings.GOOGLE_ANALYTICS['request_key'], None)
+            else:
+                account = settings.GOOGLE_ANALYTICS['google_analytics_id']
+            assert account
+        except:
+            return ''
+
         # intialise the parameters collection
         params = {}
         # collect the campaign tracking parameters from the request

--- a/google_analytics/utils.py
+++ b/google_analytics/utils.py
@@ -52,11 +52,15 @@ def build_ga_params(request, path=None, event=None, referer=None):
 
     # get the account id
     try:
-        account = settings.GOOGLE_ANALYTICS['google_analytics_id']
+        if 'request_key' in settings.GOOGLE_ANALYTICS:
+            account = getattr(request, settings.GOOGLE_ANALYTICS['request_key'], None)
+            if not account: return {}
+        else:
+            account = settings.GOOGLE_ANALYTICS['google_analytics_id']
     except:
         raise Exception("No Google Analytics ID configured")
 
-    # determine the domian
+    # determine the domain
     domain = meta.get('HTTP_HOST', '')
 
     # determine the referrer


### PR DESCRIPTION
Add support for an optional GOOGLE_ANALYTICS['request_key'] setting
to allow the Google Analytics tracking code to be supplied by other
middleware, as an alternative to a global setting.