### PR TITLE
Fix bug in middleware introduced in 2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - sudo apt-get install -qq libtidy-dev python-dev
   - find . -name '*.pyc' -delete
 install:
-  - "pip install coveralls coverage django-setuptest --use-wheel"
+  - "pip install coveralls coverage django-setuptest responses --use-wheel"
   - "pip install -e ."
 script:
   - coverage run --source=google_analytics setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ install:
   - "pip install coveralls coverage django-setuptest responses --use-wheel"
   - "pip install -e ."
 script:
-  - coverage run --source=google_analytics setup.py test
   - DJANGO_SETTINGS_MODULE=test_settings coverage run --source='google_analytics' `which django-admin.py` test
 after_success:
   - coveralls

--- a/google_analytics/middleware.py
+++ b/google_analytics/middleware.py
@@ -11,9 +11,15 @@ class GoogleAnalyticsMiddleware(object):
             if any(exclude):
                 return response
 
+        # get the account id
+        try:
+            account = settings.GOOGLE_ANALYTICS['google_analytics_id']
+        except:
+            raise Exception("No Google Analytics ID configured")
+
         path = request.path
         referer = request.META.get('HTTP_REFERER', '')
-        params = build_ga_params(request, path=path, referer=referer)
+        params = build_ga_params(request, account, path=path, referer=referer)
         response = set_cookie(params, response)
         send_ga_tracking.delay(params)
         return response

--- a/google_analytics/tasks.py
+++ b/google_analytics/tasks.py
@@ -1,4 +1,4 @@
-import httplib2
+import requests
 from celery.task import task
 
 
@@ -8,15 +8,5 @@ def send_ga_tracking(params):
     user_agent = params.get('user_agent')
     language = params.get('language')
 
-    # send the request
-    http = httplib2.Http()
-    try:
-        resp, content = http.request(
-            utm_url, 'GET',
-            headers={
-                'User-Agent': user_agent,
-                'Accepts-Language:': language
-            }
-        )
-    except httplib2.HttpLib2Error:
-        raise Exception("Error opening: %s" % utm_url)
+    headers = {'User-Agent': user_agent, 'Accepts-Language:': language}
+    requests.get(utm_url, headers=headers)

--- a/google_analytics/views.py
+++ b/google_analytics/views.py
@@ -1,4 +1,4 @@
-import httplib2
+import requests
 import re
 import struct
 
@@ -38,25 +38,22 @@ def google_analytics_request(request, response, path=None, event=None):
     utm_url = params.get('utm_url')
     user_agent = params.get('user_agent')
     language = params.get('language')
-    # send the request
-    http = httplib2.Http()
-    try:
-        resp, content = http.request(
-            utm_url, 'GET',
-            headers={
-                'User-Agent': user_agent,
-                'Accepts-Language': language
-            }
-        )
-        # send debug headers if debug mode is set
-        if request.GET.get('utmdebug', False):
-            response['X-GA-MOBILE-URL'] = utm_url
-            response['X-GA-RESPONSE'] = resp
 
-        # return the augmented response
-        return response
-    except httplib2.HttpLib2Error:
-        raise Exception("Error opening: %s" % utm_url)
+    # send the request
+    resp = requests.get(
+        utm_url,
+        headers={
+            'User-Agent': user_agent,
+            'Accepts-Language': language
+        }
+    )
+    # send debug headers if debug mode is set
+    if request.GET.get('utmdebug', False):
+        response['X-GA-MOBILE-URL'] = utm_url
+        response['X-GA-RESPONSE'] = resp
+
+    # return the augmented response
+    return response
 
 
 @never_cache

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@ setup(
     url='http://github.com/praekelt/django-google-analytics',
     packages=find_packages(),
     install_requires=[
-        'django',
+        'django<1.10',
         'django-celery',
-        'httplib2',
+        'requests',
     ],
     include_package_data=True,
     tests_require=[

--- a/test_settings.py
+++ b/test_settings.py
@@ -30,6 +30,4 @@ ROOT_URLCONF = 'google_analytics.urls'
 
 CUSTOM_UIP_HEADER = 'HTTP_X_IORG_FBS_UIP'
 
-CELERY_RESULT_BACKEND = BROKER_URL = 'django://'
-CELERY_ALWAYS_EAGER = True
 TEST_RUNNER = 'djcelery.contrib.test_runner.CeleryTestSuiteRunner'

--- a/test_settings.py
+++ b/test_settings.py
@@ -6,29 +6,20 @@ DATABASES = {
     }
 }
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sites',
 
+    'djcelery',
     'google_analytics',
     'django.contrib.sessions',
-)
+    'kombu.transport.django',
+]
 
-TEMPLATE_CONTEXT_PROCESSORS = (
-    "django.contrib.auth.context_processors.auth",
-    "django.core.context_processors.debug",
-    "django.core.context_processors.i18n",
-    "django.core.context_processors.media",
-    "django.core.context_processors.static",
-    "django.core.context_processors.tz",
-    "django.contrib.messages.context_processors.messages",
-    "django.core.context_processors.request",
-)
-
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE_CLASSES = [
     'django.contrib.sessions.middleware.SessionMiddleware',
-)
+]
 
 STATIC_URL = ''
 SITE_ID = 1
@@ -38,3 +29,7 @@ GOOGLE_ANALYTICS = {
 ROOT_URLCONF = 'google_analytics.urls'
 
 CUSTOM_UIP_HEADER = 'HTTP_X_IORG_FBS_UIP'
+
+CELERY_RESULT_BACKEND = BROKER_URL = 'django://'
+CELERY_ALWAYS_EAGER = True
+TEST_RUNNER = 'djcelery.contrib.test_runner.CeleryTestSuiteRunner'


### PR DESCRIPTION
- [x] `build_ga_params` expects account to be supplied
- [x] Replace `httplib2` with `requests` for better testing with `responses` 