### PR TITLE
Remove GA self referal traffic

### DIFF
--- a/google_analytics/tests/test_ga.py
+++ b/google_analytics/tests/test_ga.py
@@ -163,32 +163,31 @@ class GoogleAnalyticsTestCase(TestCase):
 
     @responses.activate
     def test_build_ga_params_for_direct_referals(self):
-        headers = {'HTTP_HOST': 'test.com'}
+        headers = {'HTTP_HOST': 'localhost:8000'}
         request = self.make_fake_request('/somewhere/', headers)
         ga_dict_without_referal = build_ga_params(
             request, 'ua-test-id', '/some/path/',)
         ga_dict_without_direct_referal = build_ga_params(
             request, 'ua-test-id', '/some/path/',
-            referer='localhost:8000/some/other/path/')
+            referer='http://test.com/some/path/')
 
         ga_dict_with_direct_referal = build_ga_params(
             request, 'ua-test-id', '/some/path/',
-            referer='localhost:8000/some/other/path/')
+            referer='http://localhost:8000/some/path/')
 
         # None: if referal is not set
         self.assertEqual(
             parse_qs(ga_dict_without_referal.get('utm_url')).get('dr'), None)
-
         # Exlcude referals from the same host
         self.assertEqual(
             parse_qs(
                 ga_dict_without_direct_referal.get('utm_url')).get('dr'),
-            ['localhost:8000/some/other/path/'])
+            ['http://test.com/some/path/'])
         # include referals from another host
         self.assertEqual(
             parse_qs(
                 ga_dict_with_direct_referal.get('utm_url')).get('dr'),
-            ['localhost:8000/some/other/path/'])
+            ['/some/path/'])
 
     @responses.activate
     @override_settings(

--- a/google_analytics/tests/test_ga.py
+++ b/google_analytics/tests/test_ga.py
@@ -178,12 +178,12 @@ class GoogleAnalyticsTestCase(TestCase):
         # None: if referal is not set
         self.assertEqual(
             parse_qs(ga_dict_without_referal.get('utm_url')).get('dr'), None)
-        # Exlcude referals from the same host
+        # Include referals from another host
         self.assertEqual(
             parse_qs(
                 ga_dict_without_direct_referal.get('utm_url')).get('dr'),
             ['http://test.com/some/path/'])
-        # include referals from another host
+        # Exlcude referals from the same host
         self.assertEqual(
             parse_qs(
                 ga_dict_with_direct_referal.get('utm_url')).get('dr'),

--- a/google_analytics/tests/test_ga.py
+++ b/google_analytics/tests/test_ga.py
@@ -169,11 +169,11 @@ class GoogleAnalyticsTestCase(TestCase):
             request, 'ua-test-id', '/some/path/',)
         ga_dict_without_direct_referal = build_ga_params(
             request, 'ua-test-id', '/some/path/',
-            referer='test.com')
+            referer='localhost:8000/some/other/path/')
 
         ga_dict_with_direct_referal = build_ga_params(
             request, 'ua-test-id', '/some/path/',
-            referer='notest.com')
+            referer='localhost:8000/some/other/path/')
 
         # None: if referal is not set
         self.assertEqual(
@@ -183,12 +183,12 @@ class GoogleAnalyticsTestCase(TestCase):
         self.assertEqual(
             parse_qs(
                 ga_dict_without_direct_referal.get('utm_url')).get('dr'),
-            None)
+            ['localhost:8000/some/other/path/'])
         # include referals from another host
         self.assertEqual(
             parse_qs(
                 ga_dict_with_direct_referal.get('utm_url')).get('dr'),
-            ['notest.com'])
+            ['localhost:8000/some/other/path/'])
 
     @responses.activate
     @override_settings(

--- a/google_analytics/tests/test_ga.py
+++ b/google_analytics/tests/test_ga.py
@@ -150,16 +150,16 @@ class GoogleAnalyticsTestCase(TestCase):
     def test_build_ga_params_for_user_id(self):
         request = self.make_fake_request('/somewhere/')
 
-        ga_dict_without_dr = build_ga_params(
+        ga_dict_without_uid = build_ga_params(
             request, 'ua-test-id', '/some/path/',)
 
-        ga_dict_with_dr = build_ga_params(
+        ga_dict_with_uid = build_ga_params(
             request, 'ua-test-id', '/some/path/', user_id='402-3a6')
 
         self.assertEqual(
-            parse_qs(ga_dict_without_dr.get('utm_url')).get('uid'), None)
+            parse_qs(ga_dict_without_uid.get('utm_url')).get('uid'), None)
         self.assertEqual(
-            parse_qs(ga_dict_with_dr.get('utm_url')).get('uid'), ['402-3a6'])
+            parse_qs(ga_dict_with_uid.get('utm_url')).get('uid'), ['402-3a6'])
 
     @responses.activate
     def test_build_ga_params_for_direct_referals(self):

--- a/google_analytics/utils.py
+++ b/google_analytics/utils.py
@@ -10,6 +10,7 @@ from google_analytics import CAMPAIGN_TRACKING_PARAMS
 
 from six import text_type
 from six.moves.urllib.parse import quote, urlencode
+from urllib.parse import urlparse
 
 VERSION = '1'
 COOKIE_NAME = '__utmmobile'
@@ -60,8 +61,9 @@ def build_ga_params(
 
     # determine the referrer
     referer = referer or request.GET.get('r', '')
-    if referer == domain:
-        referer = ''
+    parse_referer = urlparse(referer)
+    if parse_referer.netloc == domain:
+        referer = parse_referer.path
 
     custom_uip = None
     if hasattr(settings, 'CUSTOM_UIP_HEADER') and settings.CUSTOM_UIP_HEADER:

--- a/google_analytics/utils.py
+++ b/google_analytics/utils.py
@@ -10,7 +10,10 @@ from google_analytics import CAMPAIGN_TRACKING_PARAMS
 
 from six import text_type
 from six.moves.urllib.parse import quote, urlencode
-from urllib.parse import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 VERSION = '1'
 COOKIE_NAME = '__utmmobile'

--- a/google_analytics/utils.py
+++ b/google_analytics/utils.py
@@ -60,6 +60,8 @@ def build_ga_params(
 
     # determine the referrer
     referer = referer or request.GET.get('r', '')
+    if referer == domain:
+        referer = ''
 
     custom_uip = None
     if hasattr(settings, 'CUSTOM_UIP_HEADER') and settings.CUSTOM_UIP_HEADER:
@@ -84,7 +86,7 @@ def build_ga_params(
         'z': str(random.randint(0, 0x7fffffff)),
         'dh': domain,
         'sr': '',
-        'dr': '_',
+        'dr': referer,
         'dp': quote(path.encode('utf-8')),
         'tid': account,
         'cid': visitor_id,


### PR DESCRIPTION
So the GA report was showing a lot of self referal traffic, this is  users go from `test.com/home/` to `test.com/sections/`. I added an check for when the referal traffic is coming from the same domain. this will reduce the dr to `/sections/`