### PR TITLE
Bug/ga tag not sending query params and campaign params

### DIFF
--- a/google_analytics/templatetags/google_analytics_tags.py
+++ b/google_analytics/templatetags/google_analytics_tags.py
@@ -31,7 +31,7 @@ def google_analytics(context, tracking_code=None, debug=False):
     if referer:
         params['r'] = referer
     # remove collected parameters from the path and pass it on
-    path = request.path
+    path = request.get_full_path()
     parsed_url = urlparse(path)
     query = parse_qs(parsed_url.query)
     for param in params:

--- a/google_analytics/templatetags/google_analytics_tags.py
+++ b/google_analytics/templatetags/google_analytics_tags.py
@@ -37,7 +37,7 @@ def google_analytics(context, tracking_code=None, debug=False):
     for param in params:
         if param in query:
             del query[param]
-    query = urlencode(query)
+    query = urlencode(query, doseq=True)
     new_url = parsed_url._replace(query=query)
     params['p'] = new_url.geturl()
     params['tracking_code'] = tracking_code or settings.GOOGLE_ANALYTICS[

--- a/google_analytics/templatetags/google_analytics_tags.py
+++ b/google_analytics/templatetags/google_analytics_tags.py
@@ -22,7 +22,7 @@ def google_analytics(context, tracking_code=None, debug=False):
     # intialise the parameters collection
     params = {}
     # collect the campaign tracking parameters from the request
-    for param in CAMPAIGN_TRACKING_PARAMS:
+    for param in CAMPAIGN_TRACKING_PARAMS.values():
         value = request.GET.get(param, None)
         if value:
             params[param] = value

--- a/google_analytics/tests/test_templatetags_google_analytics_tags.py
+++ b/google_analytics/tests/test_templatetags_google_analytics_tags.py
@@ -1,3 +1,5 @@
+from urllib.parse import parse_qs
+
 from django.template import Context, Template
 from django.test import RequestFactory, TestCase, override_settings
 from google_analytics.templatetags.google_analytics_tags import \
@@ -10,8 +12,8 @@ class GoogleAnalyticsTagsTestCase(TestCase):
     )
 
     def setUp(self):
-        factory = RequestFactory()
-        self.request = factory.get('/')
+        self.factory = RequestFactory()
+        self.request = self.factory.get('/')
 
     def test_tracking_code_used_if_passed_in(self):
         context = Context({'request': self.request})
@@ -28,3 +30,39 @@ class GoogleAnalyticsTagsTestCase(TestCase):
         context = Context({'request': self.request})
         rendered_template = google_analytics(context)
         self.assertEqual('', rendered_template)
+
+    def test_query_param(self):
+        request = self.factory.get('/?test=abc')
+        context = Context({'request': request})
+
+        rendered_template = google_analytics(context, tracking_code='my-code')
+
+        parsed_qs = parse_qs(rendered_template)
+        self.assertEqual(parsed_qs['tracking_code'][0], "my-code")
+        self.assertEqual(parsed_qs['p'][0], "/?test=abc")
+
+    def test_query_param_with_multiple_values_with_same_key(self):
+        request = self.factory.get('/?test=abc&test=xyz')
+        context = Context({'request': request})
+
+        rendered_template = google_analytics(context, tracking_code='my-code')
+
+        parsed_qs = parse_qs(rendered_template)
+        self.assertEqual(parsed_qs['tracking_code'][0], "my-code")
+        self.assertEqual(parsed_qs['p'][0], "/?test=abc&test=xyz")
+
+    def test_query_param_with_campaign(self):
+        request = self.factory.get(
+            '/en/?utm_content=content&utm_term=term&utm_source=source&utm_medium=medium&utm_campaign=campaign')
+        context = Context({'request': request})
+
+        rendered_template = google_analytics(context, tracking_code='my-code')
+
+        parsed_qs = parse_qs(rendered_template)
+        self.assertEqual(parsed_qs['tracking_code'][0], "my-code")
+        self.assertEqual(parsed_qs['p'][0], "/en/")
+        self.assertEqual(parsed_qs['utm_content'][0], "content")
+        self.assertEqual(parsed_qs['utm_term'][0], "term")
+        self.assertEqual(parsed_qs['utm_source'][0], "source")
+        self.assertEqual(parsed_qs['utm_medium'][0], "medium")
+        self.assertEqual(parsed_qs['utm_campaign'][0], "campaign")


### PR DESCRIPTION
issues
- query params in request url aren't being sent to google analytics
- campaign params aren't processed

solutions
- used full URL instead of request path to get query params
- fixes campaign params name access

added test cases to check fixes